### PR TITLE
Make google_search_features.js work on pages without CSS

### DIFF
--- a/google_search_features.js
+++ b/google_search_features.js
@@ -95,7 +95,7 @@ const BlinkFeatureNameToCaniuseName = {
  * @param {string} propName Property name to filter on.
  * @return {!Array} unique array of items
  */
-function uniqueByProperty(items, propName) {
+function uniqueByProperty(items = [], propName) {
   const posts = Array.from(items.reduce((map, item) => {
     return map.set(item[propName], item);
   }, new Map()).values());


### PR DESCRIPTION
When no CSS features are used at the specified URL, it exits with an error:
```
(node:11369) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'reduce' of undefined
    at uniqueByProperty (google_search_features.js:99:34)
    at google_search_features.js:244:22
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:118:7)
```
The content of the failing page was as follows:
```
Hi
<script type="text/javascript">
  console.log(['a', 'b'].includes('b') ? 'has b' : 'no b');
</script>
```

This pull request provides a default argument to one of the utility functions to prevent said `reduce` errors.