### PR TITLE
repo should include a minimal output/ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.png
 *.pdf
-output*
+output/*
+!output/.keep
 tmp/
 user-data-dir/
 node_modules/


### PR DESCRIPTION
fixes #6

ignore everything in the output dir except the placeholder keeping the dir in the repo. that way a fresh repo and script run will have the dir present and won't spit an error and require an extra step from the tinkerer. 