### PR TITLE
More chars to slugify

### DIFF
--- a/crawlsite.js
+++ b/crawlsite.js
@@ -50,8 +50,9 @@ const OUT_DIR = process.env.OUTDIR || `output/${slugify(URL)}`;
 const crawledPages = new Map();
 const maxDepth = DEPTH; // Subpage depth to crawl site.
 
+// Replaces characters from the URL which are illegal in a file path for working dir and saving screenshots.
 function slugify(str) {
-  return str.replace(/[\/:]/g, '_');
+    return str.replace(/[\/:?*%|"<>. ]/g, '_');
 }
 
 function mkdirSync(dirPath) {


### PR DESCRIPTION
Added more characters to slugify function to fix [issue #25](https://github.com/GoogleChromeLabs/puppeteer-examples/issues/25), query strings in URLs break file-related functions.