### PR TITLE
Added bot user agent to non-scrolled page

### DIFF
--- a/lazyimages_without_scroll_events.js
+++ b/lazyimages_without_scroll_events.js
@@ -125,6 +125,7 @@ async function screenshotPageWithoutScroll(url) {
   //   });
   // });
 
+  page.setUserAgent('Googlebot/2.1 (+http://www.googlebot.com/bot.html)');
   await page.goto(url, {waitUntil: 'networkidle2'});
   await page.waitFor(WAIT_FOR); // Wait a bit more in case other things are loading.
   // await waitForNetworkIdle(page, 'networkidle0'); // wait for network to be idle.


### PR DESCRIPTION
While trying this script with both LazySizes and LazyLoad libraries, I found out that the tests would always fail. It seems that the bot user agent wasn't specified, either unintentionally or not, but it caused much confusion.

Lazyload uses the IntersectionObserver API, so the test failing cause lots of confusion about why was this happening.

Here's the issue where this was being discussed: https://github.com/verlok/lazyload/issues/277

This is the main repo for both libraries:
* LazyLoad: https://github.com/verlok/lazyload
* LazySizes: https://github.com/aFarkas/lazysizes

To clarify, I've run the script on a project i'm working on, which had two different implementations of lazyloading on different branches, one with lazysizes, another one with lazyload, and both failed, even though they are actually implemented in a way that should be compliant according to the docs (https://developers.google.com/search/docs/guides/lazy-loading).

Hope this helps.

Also, if the exclusion of the UA is intentional, It would be good to have an explanation. Someone actually asked this some time ago, but received no answer (https://github.com/GoogleChromeLabs/puppeteer-examples/issues/27).